### PR TITLE
Restrict access to S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ locals {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enable_s3_bucket_logging"></a> [enable\_s3\_bucket\_logging](#input\_enable\_s3\_bucket\_logging) | Enable S3 bucket logging | `bool` | `true` | no |
+| <a name="input_logging_bucket_restrict_access"></a> [logging\_bucket\_restrict\_access](#input\_logging\_bucket\_restrict\_access) | Set to `true` to also apply the `tfvars_restrict_access_user_ids` list to the S3 logging bucket | `bool` | `true` | no |
 | <a name="input_logging_bucket_retention"></a> [logging\_bucket\_retention](#input\_logging\_bucket\_retention) | Logging bucket retention in days. Set to 0 to keep all logs. | `number` | `30` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_tfvars_files"></a> [tfvars\_files](#input\_tfvars\_files) | Map of objects containing tfvar file paths | <pre>map(<br>    object({<br>      path = string<br>      }<br>  ))</pre> | `{}` | no |
+| <a name="input_tfvars_restrict_access_user_ids"></a> [tfvars\_restrict\_access\_user\_ids](#input\_tfvars\_restrict\_access\_user\_ids) | List of AWS User IDs that require access to the tfvars S3 bucket. If left empty, all users within the AWS account will have access | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,10 @@
 locals {
-  project_name             = var.project_name
-  aws_account_id           = data.aws_caller_identity.current.account_id
-  enable_logs_bucket       = var.enable_s3_bucket_logging
-  logging_bucket_retention = var.logging_bucket_retention
-  tfvars_files             = var.tfvars_files
+  project_name                            = var.project_name
+  aws_account_id                          = data.aws_caller_identity.current.account_id
+  enable_logs_bucket                      = var.enable_s3_bucket_logging
+  logging_bucket_retention                = var.logging_bucket_retention
+  tfvars_files                            = var.tfvars_files
+  tfvars_restrict_access_user_ids         = var.tfvars_restrict_access_user_ids
+  logging_bucket_restrict_access          = var.logging_bucket_restrict_access
+  logging_bucket_restrict_access_user_ids = local.logging_bucket_restrict_access ? local.tfvars_restrict_access_user_ids : []
 }

--- a/policies/s3-bucket-policy-statements/restrict-access-to-list-of-users.json.tpl
+++ b/policies/s3-bucket-policy-statements/restrict-access-to-list-of-users.json.tpl
@@ -1,0 +1,16 @@
+%{if user_ids != "[]" ~}
+{
+  "Effect": "Deny",
+  "Principal": "*",
+  "Action": "s3:*",
+  "Resource": [
+    "${bucket_arn}",
+    "${bucket_arn}/*"
+  ],
+  "Condition": {
+    "StringNotLike": {
+      "aws:userId": ${user_ids}
+    }
+  }
+}
+%{ endif ~}

--- a/s3-logs.tf
+++ b/s3-logs.tf
@@ -20,6 +20,10 @@ resource "aws_s3_bucket_policy" "logs" {
       log_bucket_arn     = aws_s3_bucket.logs[0].arn
       source_bucket_arns = jsonencode([aws_s3_bucket.tfvars.arn])
       account_id         = local.aws_account_id
+      })}${length(local.tfvars_restrict_access_user_ids) != 0 ? "," : ""}
+      ${templatefile("${path.module}/policies/s3-bucket-policy-statements/restrict-access-to-list-of-users.json.tpl", {
+      bucket_arn = aws_s3_bucket.logs[0].arn,
+      user_ids   = jsonencode(local.logging_bucket_restrict_access_user_ids),
 })}
       ]
       EOT

--- a/s3-tfvars.tf
+++ b/s3-tfvars.tf
@@ -9,11 +9,17 @@ resource "aws_s3_bucket_policy" "tfvars" {
     {
       statement = <<EOT
       [
-      ${templatefile("${path.module}/policies/s3-bucket-policy-statements/enforce-tls.json.tpl", { bucket_arn = aws_s3_bucket.tfvars.arn })}
+      ${templatefile("${path.module}/policies/s3-bucket-policy-statements/enforce-tls.json.tpl", {
+      bucket_arn = aws_s3_bucket.tfvars.arn,
+      })}${length(local.tfvars_restrict_access_user_ids) != 0 ? "," : ""}
+      ${templatefile("${path.module}/policies/s3-bucket-policy-statements/restrict-access-to-list-of-users.json.tpl", {
+      bucket_arn = aws_s3_bucket.tfvars.arn,
+      user_ids   = jsonencode(local.tfvars_restrict_access_user_ids),
+})}
       ]
       EOT
-    }
-  )
+}
+)
 }
 
 resource "aws_s3_bucket_public_access_block" "tfvars" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,15 @@ variable "tfvars_files" {
   ))
   default = {}
 }
+
+variable "tfvars_restrict_access_user_ids" {
+  description = "List of AWS User IDs that require access to the tfvars S3 bucket. If left empty, all users within the AWS account will have access"
+  type        = list(string)
+  default     = []
+}
+
+variable "logging_bucket_restrict_access" {
+  description = "Set to `true` to also apply the `tfvars_restrict_access_user_ids` list to the S3 logging bucket"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
* Allows specifying a list of AWS User IDs, to restrict access to the tfvars S3 bucket
* Also allows conditionally setting the same policy to the S3 logging bucket (enabled by default)