### PR TITLE
Allow overwritting S3 file key

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ locals {
 | <a name="input_enable_s3_bucket_logging"></a> [enable\_s3\_bucket\_logging](#input\_enable\_s3\_bucket\_logging) | Enable S3 bucket logging | `bool` | `true` | no |
 | <a name="input_logging_bucket_retention"></a> [logging\_bucket\_retention](#input\_logging\_bucket\_retention) | Logging bucket retention in days. Set to 0 to keep all logs. | `number` | `30` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
-| <a name="input_tfvars_files"></a> [tfvars\_files](#input\_tfvars\_files) | Map of objects containing tfvar file paths | <pre>map(<br>    object({<br>      path = string<br>      }<br>  ))</pre> | `{}` | no |
+| <a name="input_tfvars_files"></a> [tfvars\_files](#input\_tfvars\_files) | Map of objects containing tfvar file paths | <pre>map(<br>    object({<br>      path = string<br>      key  = optional(string, "")<br>      }<br>  ))</pre> | `{}` | no |
 | <a name="input_tfvars_restrict_access_user_ids"></a> [tfvars\_restrict\_access\_user\_ids](#input\_tfvars\_restrict\_access\_user\_ids) | List of AWS User IDs that require access to the tfvars S3 bucket. If left empty, all users within the AWS account will have access | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/s3-tfvars-files.tf
+++ b/s3-tfvars-files.tf
@@ -2,7 +2,7 @@ resource "aws_s3_object" "tfvar_file" {
   for_each = local.tfvars_files
 
   bucket     = aws_s3_bucket.tfvars.id
-  key        = each.value["path"]
+  key        = each.value["key"] == "" ? each.value["path"] : each.value["key"]
   source     = each.value["path"]
   kms_key_id = aws_kms_key.tfvars.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,7 @@ variable "tfvars_files" {
   type = map(
     object({
       path = string
+      key  = optional(string, "")
       }
   ))
   default = {}


### PR DESCRIPTION
* By default, the key will be the same as the provided source path.
* Setting the `key` within the `input_tfvars_files` object will now set the S3 bucket key