### PR TITLE
Run terraform-docs within Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "postUpdateOptions": {
+    "enabled": true,
+    "commands": [
+      "docker run --rm --volume $(pwd):/terraform-docs -w /terraform-docs -u $(id -u) quay.io/terraform-docs/terraform-docs:0.16.0 .",
+      "git add .",
+      "git commit -m '${renovateCommitMessage} - Terraform Docs'"
+    ]
+  }
 }


### PR DESCRIPTION
* When Renovate updates terraform dependencies, the checks will fail because the terraform documentation won't have been updated to reflect the change.
* This utilises the `postUpdateOptions` to run terraform-docs using their docker image, and then adding it as a seperate commit.